### PR TITLE
DSOPS-3 Create TF module template for CI CodePipeline in Shared Service Account

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+#### PR description
+
+What is it for?
+
+#### Testing instructions
+
+-
+-
+
+#### JIRA ticket information
+
+Story: [DSOPS-000](https://jira.theglobeandmail.com/browse/DSOPS-000)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Notes:
         ...
         ...
     ```
+4. AWS CloudTrail data events need to be configured in the shared service account to log S3 object-level API operations in the codepipeline buckets. The logs will be forwarded to the logging bucket in the central logging account. For example of how to log all S3 bucket object events in CloudTrail, see terraform doc [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail).
 
 ## Usage
 ### Lambda

--- a/README.md
+++ b/README.md
@@ -4,34 +4,34 @@ The output artifact can be used to trigger the code pipeline for CD (i.e. deploy
 For multi-region build, modify the module to replicate the output artifact to an S3 bucket in the same region as the target deployment code pipeline.
 The module currently supports multi-region build for lambda, ECS and ECR in the N.Virginia and Ireland regions.
 
-Note:
+Notes:
 1. The account that owns the github token must have admin access on the repo in order to generate a github webhook.
 2. If `use_docker_credentials` is set to `true`, the environment variables `DOCKERHUB_USER` and `DOCKERHUB_PASS` are exposed via codebuild.
 
-You can add these 2 lines to the beginning of your `build` phase commands in `buildspec.yml` to login to Dockerhub.
+    You can add these 2 lines to the beginning of your `build` phase commands in `buildspec.yml` to login to Dockerhub.
 
-```yml
-  build:
-    commands:
-      - echo "Logging into Dockerhub..."
-      - docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASS}
-      ...
-      ...
-```
+    ```yml
+    build:
+        commands:
+        - echo "Logging into Dockerhub..."
+        - docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASS}
+        ...
+        ...
+    ```
 3. If `use_repo_access_github_token` is set to `true`, the environment variable `REPO_ACCESS_GITHUB_TOKEN_SECRETS_ID` is exposed via codebuild.
 
-You can add this line to the beginning of your `build` phase commands in `buildspec.yml` to assign the environment variable to local variable `GITHUB_TOKEN`.
+    You can add this line to the beginning of your `build` phase commands in `buildspec.yml` to assign the environment variable to local variable `GITHUB_TOKEN`.
 
-```yml
-  build:
-    commands:
-      - export GITHUB_TOKEN=${REPO_ACCESS_GITHUB_TOKEN_SECRETS_ID}
-      ...
-      ...
-      - docker build -t $REPOSITORY_URI:latest --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} .
-      ...
-      ...
-```
+    ```yml
+    build:
+        commands:
+        - export GITHUB_TOKEN=${REPO_ACCESS_GITHUB_TOKEN_SECRETS_ID}
+        ...
+        ...
+        - docker build -t $REPOSITORY_URI:latest --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} .
+        ...
+        ...
+    ```
 
 ## Usage
 ### Lambda

--- a/README.md
+++ b/README.md
@@ -1,2 +1,298 @@
 # aws-ci-codepipeline
-The AWS code pipeline for CI and artifact stores in a shared service account.
+The AWS code pipeline for CI (i.e. build). It creates a codebuild project and S3 artifact bucket in a shared service account.
+The output artifact can be used to trigger the code pipeline for CD (i.e. deployment) in other AWS account(s).
+For multi-region build, modify the module to replicate the output artifact to an S3 bucket in the same region as the target deployment code pipeline.
+The module currently supports multi-region build for lambda, ECS and ECR in the N.Virginia and Ireland regions.
+
+Note:
+1. The account that owns the github token must have admin access on the repo in order to generate a github webhook.
+2. If `use_docker_credentials` is set to `true`, the environment variables `DOCKERHUB_USER` and `DOCKERHUB_PASS` are exposed via codebuild.
+
+You can add these 2 lines to the beginning of your `build` phase commands in `buildspec.yml` to login to Dockerhub.
+
+```yml
+  build:
+    commands:
+      - echo "Logging into Dockerhub..."
+      - docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASS}
+      ...
+      ...
+```
+3. If `use_repo_access_github_token` is set to `true`, the environment variable `REPO_ACCESS_GITHUB_TOKEN_SECRETS_ID` is exposed via codebuild.
+
+You can add this line to the beginning of your `build` phase commands in `buildspec.yml` to assign the environment variable to local variable `GITHUB_TOKEN`.
+
+```yml
+  build:
+    commands:
+      - export GITHUB_TOKEN=${REPO_ACCESS_GITHUB_TOKEN_SECRETS_ID}
+      ...
+      ...
+      - docker build -t $REPOSITORY_URI:latest --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} .
+      ...
+      ...
+```
+
+## Usage
+### Lambda
+```hcl
+module "lambda_ci_pipeline" {
+  source = "github.com/globeandmail/aws-ci-codepipeline?ref=1.0"
+
+  name                                     = "app-name"
+  deploy_type                              = "lambda"
+  aws_organization_id                      = "aws-organization-id"
+  github_repo_owner                        = "github-account-name"
+  github_repo_name                         = "github-repo-name"
+  github_branch_name                       = "github-branch-name"
+  github_oauth_token                       = data.aws_ssm_parameter.github_token.value
+  non_default_aws_provider_configurations  = {
+                                               ireland = {
+                                                 region_name = "region-name",
+                                                 profile_name = "profile-name",
+                                                 allowed_account_ids = ["account-id"]
+                                               }
+                                             }
+  lambda_function_name                     = "lambda-function-name"
+  s3_bucket_force_destroy                  = true
+  create_cross_region_resources            = true
+  create_ireland_region_resources          = true
+  svcs_account_ireland_kms_cmk_arn_for_s3  = "svcs-account-ireland-kms-cmk-arn-for-s3"
+  svcs_account_virginia_kms_cmk_arn_for_s3 = "svcs-account-virginia-kms-cmk-arn-for-s3"
+  tags                                     = {
+                                               Environment = var.environment
+                                             }
+}
+```
+
+### ECS
+```hcl
+module "ecs_ci_pipeline" {
+  source = "github.com/globeandmail/aws-ci-codepipeline?ref=1.0"
+
+  name                                      = "app-name"
+  deploy_type                               = "ecs"
+  aws_organization_id                       = "aws-organization-id"
+  github_repo_owner                         = "github-account-name"
+  github_repo_name                          = "github-repo-name"
+  github_branch_name                        = "github-branch-name"
+  github_oauth_token                        = data.aws_ssm_parameter.github_token.value
+  non_default_aws_provider_configurations   = {
+                                                ireland = {
+                                                  region_name = "region-name",
+                                                  profile_name = "profile-name",
+                                                  allowed_account_ids = ["account-id"]
+                                                }
+                                              }
+  s3_bucket_force_destroy                   = true
+  create_cross_region_resources             = true
+  create_ireland_region_resources           = true
+  svcs_account_ireland_kms_cmk_arn_for_s3   = "svcs-account-ireland-kms-cmk-arn-for-s3"
+  svcs_account_virginia_kms_cmk_arn_for_s3  = "svcs-account-virginia-kms-cmk-arn-for-s3"
+  ecr_name                                  = "ecr-repo-name"
+  use_docker_credentials                    = true
+  use_repo_access_github_token              = true
+  svcs_account_github_token_aws_secret_arn  = "svcs-account-github-token-aws-secret-arn"
+  svcs_account_github_token_aws_kms_cmk_arn = "svcs-account-github-token-aws-kms-cmk-arn"
+  tags                                      = {
+                                                Environment = var.environment
+                                              }
+}
+```
+
+### ECR
+```hcl
+module "ecr_ci_pipeline" {
+  source = "github.com/globeandmail/aws-ci-codepipeline?ref=1.0"
+
+  name                                      = "app-name"
+  deploy_type                               = "ecr"
+  aws_organization_id                       = "aws-organization-id"
+  github_repo_owner                         = "github-account-name"
+  github_repo_name                          = "github-repo-name"
+  github_branch_name                        = "github-branch-name"
+  github_oauth_token                        = data.aws_ssm_parameter.github_token.value
+  non_default_aws_provider_configurations   = {
+                                                ireland = {
+                                                  region_name = "region-name",
+                                                  profile_name = "profile-name",
+                                                  allowed_account_ids = ["account-id"]
+                                                }
+                                              }
+  create_cross_region_resources             = false
+  create_ireland_region_resources           = false
+  svcs_account_virginia_kms_cmk_arn_for_s3  = "svcs-account-virginia-kms-cmk-arn-for-s3"
+  ecr_name                                  = "ecr-repo-name"
+  use_docker_credentials                    = true
+  use_repo_access_github_token              = true
+  svcs_account_github_token_aws_secret_arn  = "svcs-account-github-token-aws-secret-arn"
+  svcs_account_github_token_aws_kms_cmk_arn = "svcs-account-github-token-aws-kms-cmk-arn"
+  tags                                      = {
+                                                Environment = var.environment
+                                              }
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws.ireland"></a> [aws.ireland](#provider\_aws.ireland) | n/a |
+| <a name="provider_github"></a> [github](#provider\_github) | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_organization_id"></a> [aws\_organization\_id](#input\_aws\_organization\_id) | (Required) The AWS organization ID. | `string` | n/a | yes |
+| <a name="input_build_compute_type"></a> [build\_compute\_type](#input\_build\_compute\_type) | (Optional) The codebuild environment compute type. Defaults to BUILD\_GENERAL1\_SMALL. | `string` | `"BUILD_GENERAL1_SMALL"` | no |
+| <a name="input_buildspec"></a> [buildspec](#input\_buildspec) | (Optional) The name of the buildspec file to use with codebuild. Defaults to buildspec.yml. | `string` | `"buildspec.yml"` | no |
+| <a name="input_codebuild_image"></a> [codebuild\_image](#input\_codebuild\_image) | (Optional) The codebuild image to use. Defaults to aws/codebuild/amazonlinux2-x86\_64-standard:1.0. | `string` | `"aws/codebuild/amazonlinux2-x86_64-standard:1.0"` | no |
+| <a name="input_create_cross_region_resources"></a> [create\_cross\_region\_resources](#input\_create\_cross\_region\_resources) | (Required) Create the pipeline associated resources in all regions specified in var.non\_default\_aws\_provider\_configurations.<br>                Set to true if var.deploy\_type is ecs or lambda. | `bool` | n/a | yes |
+| <a name="input_create_github_webhook"></a> [create\_github\_webhook](#input\_create\_github\_webhook) | (Optional) Create the github webhook that triggers codepipeline. Defaults to true. | `bool` | `true` | no |
+| <a name="input_create_ireland_region_resources"></a> [create\_ireland\_region\_resources](#input\_create\_ireland\_region\_resources) | (Required) Create the pipeline associated resources in the Ireland region.<br>                Set to true if var.deploy\_type is ecs or lambda. | `bool` | n/a | yes |
+| <a name="input_deploy_type"></a> [deploy\_type](#input\_deploy\_type) | (Required) Must be one of the following ( ecr, ecs, lambda ). | `string` | n/a | yes |
+| <a name="input_ecr_name"></a> [ecr\_name](#input\_ecr\_name) | (Optional) The name of the ECR repo. Required if var.deploy\_type is ecr or ecs. | `string` | `null` | no |
+| <a name="input_github_branch_name"></a> [github\_branch\_name](#input\_github\_branch\_name) | (Optional) The git branch name to use for the codebuild project. Defaults to master. | `string` | `"master"` | no |
+| <a name="input_github_oauth_token"></a> [github\_oauth\_token](#input\_github\_oauth\_token) | (Required) The GitHub oauth token. | `string` | n/a | yes |
+| <a name="input_github_repo_name"></a> [github\_repo\_name](#input\_github\_repo\_name) | (Required) The name of the GitHub repository. | `string` | n/a | yes |
+| <a name="input_github_repo_owner"></a> [github\_repo\_owner](#input\_github\_repo\_owner) | (Required) The owner of the GitHub repo. | `string` | n/a | yes |
+| <a name="input_lambda_function_name"></a> [lambda\_function\_name](#input\_lambda\_function\_name) | (Optional) The name of the lambda function to update. Required if var.deploy\_type is lambda. | `string` | `null` | no |
+| <a name="input_logs_retention_in_days"></a> [logs\_retention\_in\_days](#input\_logs\_retention\_in\_days) | (Optional) Days to keep the cloudwatch logs for the codebuild project. Defaults to 14. | `number` | `14` | no |
+| <a name="input_name"></a> [name](#input\_name) | (Required) The name associated with the pipeline and assoicated resources. i.e.: app-name. | `string` | n/a | yes |
+| <a name="input_non_default_aws_provider_configurations"></a> [non\_default\_aws\_provider\_configurations](#input\_non\_default\_aws\_provider\_configurations) | (Required) A mapping of AWS provider configurations for cross-region resources creation.<br>                The configuration for Ireland region in the shared service account is required at the minimum. | <pre>map(object({<br>    region_name = string,<br>    profile_name = string,<br>    allowed_account_ids = list(string)<br>  }))</pre> | `{}` | no |
+| <a name="input_privileged_mode"></a> [privileged\_mode](#input\_privileged\_mode) | (Optional) Use privileged mode for docker containers. Defaults to false. | `bool` | `false` | no |
+| <a name="input_s3_bucket_force_destroy"></a> [s3\_bucket\_force\_destroy](#input\_s3\_bucket\_force\_destroy) | (Optional) Delete all objects in S3 bucket upon bucket deletion. S3 objects are not recoverable.<br>                Set to true if var.deploy\_type is ecs or lambda. Defaults to false. | `bool` | `false` | no |
+| <a name="input_svcs_account_github_token_aws_kms_cmk_arn"></a> [svcs\_account\_github\_token\_aws\_kms\_cmk\_arn](#input\_svcs\_account\_github\_token\_aws\_kms\_cmk\_arn) | (Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting the repo access Github token AWS secret.<br>                The key is created in the shared service account.<br>                Required if var.use\_repo\_access\_github\_token is true. | `string` | `null` | no |
+| <a name="input_svcs_account_github_token_aws_secret_arn"></a> [svcs\_account\_github\_token\_aws\_secret\_arn](#input\_svcs\_account\_github\_token\_aws\_secret\_arn) | (Optional) The AWS secret ARN for the repo access Github token.<br>                The secret is created in the shared service account.<br>                Required if var.use\_repo\_access\_github\_token is true. | `string` | `null` | no |
+| <a name="input_svcs_account_ireland_kms_cmk_arn_for_s3"></a> [svcs\_account\_ireland\_kms\_cmk\_arn\_for\_s3](#input\_svcs\_account\_ireland\_kms\_cmk\_arn\_for\_s3) | (Optional) The eu-west-1 region AWS KMS customer managed key ARN for encrypting s3 data.<br>                The key is created in the shared service account.<br>                Required if var.create\_ireland\_region\_resources is true. | `string` | `null` | no |
+| <a name="input_svcs_account_virginia_kms_cmk_arn_for_s3"></a> [svcs\_account\_virginia\_kms\_cmk\_arn\_for\_s3](#input\_svcs\_account\_virginia\_kms\_cmk\_arn\_for\_s3) | (Required) The us-east-1 region AWS KMS customer managed key ARN for encrypting s3 data.<br>                  The key is created in the shared service account. | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the resource | `map` | `{}` | no |
+| <a name="input_use_docker_credentials"></a> [use\_docker\_credentials](#input\_use\_docker\_credentials) | (Optional) Use dockerhub credentals stored in parameter store. Defaults to false. | `bool` | `false` | no |
+| <a name="input_use_repo_access_github_token"></a> [use\_repo\_access\_github\_token](#input\_use\_repo\_access\_github\_token) | (Optional) Allow the AWS codebuild IAM role read access to the REPO\_ACCESS\_GITHUB\_TOKEN secrets manager secret in the shared service account.<br>                Defaults to false. | `bool` | `false` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_artifact_bucket_arn"></a> [artifact\_bucket\_arn](#output\_artifact\_bucket\_arn) | n/a |
+| <a name="output_artifact_bucket_id"></a> [artifact\_bucket\_id](#output\_artifact\_bucket\_id) | n/a |
+| <a name="output_codebuild_iam_role_name"></a> [codebuild\_iam\_role\_name](#output\_codebuild\_iam\_role\_name) | n/a |
+| <a name="output_codebuild_project_arn"></a> [codebuild\_project\_arn](#output\_codebuild\_project\_arn) | n/a |
+| <a name="output_codebuild_project_id"></a> [codebuild\_project\_id](#output\_codebuild\_project\_id) | n/a |
+| <a name="output_codepipeline_arn"></a> [codepipeline\_arn](#output\_codepipeline\_arn) | n/a |
+| <a name="output_codepipeline_id"></a> [codepipeline\_id](#output\_codepipeline\_id) | n/a |
+| <a name="output_ecr_repository_arn"></a> [ecr\_repository\_arn](#output\_ecr\_repository\_arn) | n/a |
+| <a name="output_ecr_repository_name"></a> [ecr\_repository\_name](#output\_ecr\_repository\_name) | n/a |
+| <a name="output_ecr_repository_url"></a> [ecr\_repository\_url](#output\_ecr\_repository\_url) | n/a |
+| <a name="output_output_artifact_object_name"></a> [output\_artifact\_object\_name](#output\_output\_artifact\_object\_name) | n/a |
+<!-- END_TF_DOCS -->
+
+## Builspec examples
+### Lambda
+```yml
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      python: 3.7
+  build:
+    commands:
+      - pip install --upgrade pip
+      - pip install -r requirements.txt -t .
+artifacts:
+  files:
+    - '**/*'
+  secondary-artifacts:
+    function_zip_us_east_1:
+      files:
+        - '**/*'
+      name: lambda.zip
+```
+
+### ECS
+```yml
+version: 0.2
+
+env:
+  variables:
+    IMAGE_REPO_NAME: "ecr-repo-name"
+
+phases:
+  install:
+    runtime-versions:
+      docker: 18
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
+      - AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+      - REPOSITORY_URI=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${IMAGE_REPO_NAME}
+      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - IMAGE_TAG=${COMMIT_HASH:=latest}
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - docker build -t $REPOSITORY_URI:latest .
+      - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker images...
+      - docker push $REPOSITORY_URI:latest
+      - docker push $REPOSITORY_URI:$IMAGE_TAG
+      - echo Generating imagedefinitions.json
+      - printf '[{"name":"%s","imageUri":"%s"}]' $IMAGE_REPO_NAME $REPOSITORY_URI:$IMAGE_TAG > $CODEBUILD_SRC_DIR/imagedefinitions.json
+
+artifacts:
+  files: imagedefinitions.json
+  secondary-artifacts:
+    imagedefinitions_file_us_east_1:
+      files:
+        - imagedefinitions.json
+      name: imagedefinitions.zip
+```
+
+### ECR
+```yml
+version: 0.2
+
+env:
+  variables:
+    IMAGE_REPO_NAME: "ecr-repo-name"
+
+phases:
+  install:
+    runtime-versions:
+      docker: 18
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
+      - AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+      - REPOSITORY_URI=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${IMAGE_REPO_NAME}
+      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - IMAGE_TAG=${COMMIT_HASH:=latest}
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - docker build -t $REPOSITORY_URI:latest .
+      - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker images...
+      - docker push $REPOSITORY_URI:latest
+      - docker push $REPOSITORY_URI:$IMAGE_TAG
+```

--- a/aws_provider.tf
+++ b/aws_provider.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  alias = "ireland"
+  profile = lookup(var.non_default_aws_provider_configurations["ireland"], "profile_name")
+  region = lookup(var.non_default_aws_provider_configurations["ireland"], "region_name")
+  allowed_account_ids = lookup(var.non_default_aws_provider_configurations["ireland"], "allowed_account_ids")
+}
+
+provider "github" {
+  token = var.github_oauth_token
+  owner = var.github_repo_owner
+}

--- a/codebuild.tf
+++ b/codebuild.tf
@@ -113,7 +113,7 @@ data "aws_iam_policy_document" "codebuild_secrets_manager" {
       "secretsmanager:GetSecretValue"
     ]
     resources = [
-      replace(var.central_account_github_token_aws_secret_arn, "/-.{6}$/", "-??????")
+      replace(var.svcs_account_github_token_aws_secret_arn, "/-.{6}$/", "-??????")
     ]
   }
 }
@@ -135,7 +135,7 @@ data "aws_iam_policy_document" "codebuild_kms" {
       ]
 
       resources = [
-        var.central_account_github_token_aws_kms_cmk_arn,
+        var.svcs_account_github_token_aws_kms_cmk_arn,
         var.svcs_account_virginia_kms_cmk_arn_for_s3,
         var.svcs_account_ireland_kms_cmk_arn_for_s3
       ]
@@ -150,7 +150,7 @@ data "aws_iam_policy_document" "codebuild_kms" {
       ]
 
       resources = [
-        var.central_account_github_token_aws_kms_cmk_arn,
+        var.svcs_account_github_token_aws_kms_cmk_arn,
         var.svcs_account_virginia_kms_cmk_arn_for_s3
       ]
     }
@@ -248,7 +248,7 @@ resource "aws_codebuild_project" "project" {
       for_each = var.use_repo_access_github_token ? [1] : []
       content {
         name  = "REPO_ACCESS_GITHUB_TOKEN_SECRETS_ID"
-        value = var.central_account_github_token_aws_secret_arn
+        value = var.svcs_account_github_token_aws_secret_arn
         type = "SECRETS_MANAGER"
       }
     }

--- a/codebuild.tf
+++ b/codebuild.tf
@@ -1,0 +1,263 @@
+resource "aws_cloudwatch_log_group" "group" {
+  name              = "/aws/codebuild/${local.codebuild_name}"
+  retention_in_days = var.logs_retention_in_days
+
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "codebuild_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["codebuild.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "codebuild" {
+  name               = "codebuild-${local.codebuild_name}"
+  assume_role_policy = data.aws_iam_policy_document.codebuild_assume.json
+
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "codebuild_baseline" {
+  statement {
+    actions = [
+      "logs:PutLogEvents",
+      "logs:CreateLogStream",
+      "logs:CreateLogGroup",
+    ]
+    resources = [
+      "arn:aws:logs:${local.account_region}:${local.account_id}:log-group:/aws/codebuild/${local.codebuild_name}",
+      "arn:aws:logs:${local.account_region}:${local.account_id}:log-group:/aws/codebuild/${local.codebuild_name}:*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+    ]
+    resources = [
+      "${aws_s3_bucket.artifact.arn}/*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "codebuild_baseline" {
+  name   = "codebuild-baseline-${local.codebuild_name}"
+  role   = aws_iam_role.codebuild.id
+  policy = data.aws_iam_policy_document.codebuild_baseline.json
+}
+
+data "aws_iam_policy_document" "codebuild_ecr" {
+  count = var.deploy_type == "ecr" || var.deploy_type == "ecs" ? 1 : 0
+  statement {
+
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:CompleteLayerUpload",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetRepositoryPolicy",
+      "ecr:DescribeRepositories",
+      "ecr:ListImages",
+      "ecr:DescribeImages",
+      "ecr:BatchGetImage"
+    ]
+
+    resources = [
+      aws_ecr_repository.repository[0].arn
+    ]
+  }
+
+  statement {
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage"
+    ]
+
+    resources = ["arn:aws:ecr:${local.account_region}:${local.account_id}:repository/*"]
+  }
+
+  statement {
+    actions   = ["ssm:GetParameters"]
+    resources = ["arn:aws:ssm:${local.account_region}:${local.account_id}:parameter/dockerhub/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "codebuild_ecr" {
+  # Only create this if var.deploy_type is ecr or ecs
+  count = var.deploy_type == "ecr" || var.deploy_type == "ecs" ? 1 : 0
+
+  name   = "codebuild-ecr-${local.codebuild_name}"
+  role   = aws_iam_role.codebuild.id
+  policy = data.aws_iam_policy_document.codebuild_ecr[count.index].json
+}
+
+
+data "aws_iam_policy_document" "codebuild_secrets_manager" {
+  count = var.use_repo_access_github_token ? 1 : 0
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+    resources = [
+      replace(var.central_account_github_token_aws_secret_arn, "/-.{6}$/", "-??????")
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "codebuild_secrets_manager" {
+  count  = var.use_repo_access_github_token ? 1 : 0
+  name   = "codebuild-secrets-manager-${local.codebuild_name}"
+  role   = aws_iam_role.codebuild.id
+  policy = data.aws_iam_policy_document.codebuild_secrets_manager[0].json
+}
+
+
+data "aws_iam_policy_document" "codebuild_kms" {
+  dynamic "statement" {
+    for_each = var.use_repo_access_github_token && var.create_ireland_region_resources ? [1] : []
+    content {
+      actions = [
+        "kms:Decrypt"
+      ]
+
+      resources = [
+        var.central_account_github_token_aws_kms_cmk_arn,
+        var.svcs_account_virginia_kms_cmk_arn_for_s3,
+        var.svcs_account_ireland_kms_cmk_arn_for_s3
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.use_repo_access_github_token && !var.create_ireland_region_resources ? [1] : []
+    content {
+      actions = [
+        "kms:Decrypt"
+      ]
+
+      resources = [
+        var.central_account_github_token_aws_kms_cmk_arn,
+        var.svcs_account_virginia_kms_cmk_arn_for_s3
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = !var.use_repo_access_github_token && var.create_ireland_region_resources ? [1] : []
+    content {
+      actions = [
+        "kms:Decrypt"
+      ]
+
+      resources = [
+        var.svcs_account_virginia_kms_cmk_arn_for_s3,
+        var.svcs_account_ireland_kms_cmk_arn_for_s3
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = !var.use_repo_access_github_token && !var.create_ireland_region_resources ? [1] : []
+    content {
+      actions = [
+        "kms:Decrypt"
+      ]
+
+      resources = [
+        var.svcs_account_virginia_kms_cmk_arn_for_s3
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "codebuild_kms" {
+  name   = "codebuild-kms-${local.codebuild_name}"
+  role   = aws_iam_role.codebuild.id
+  policy = data.aws_iam_policy_document.codebuild_kms.json
+}
+
+resource "aws_codebuild_project" "project" {
+  name          = local.codebuild_name
+  build_timeout = 60
+  service_role  = aws_iam_role.codebuild.arn
+
+  artifacts {
+    type = "CODEPIPELINE"
+  }
+
+  dynamic "secondary_artifacts" {
+    for_each = var.deploy_type == "lambda" || var.deploy_type == "ecs" ? [1]: []
+    content {
+      artifact_identifier = replace("${local.artifact_attributes["identifier_prefix"]}_${local.account_region}", "-", "_")
+      location = aws_s3_bucket.artifact.id
+      name = local.artifact_attributes["object_name"]
+      namespace_type = "NONE"
+      packaging = "ZIP"
+      path = local.artifact_attributes["object_path"]
+      type = "S3"
+    }
+  }
+
+  environment {
+    compute_type    = var.build_compute_type
+    image           = var.codebuild_image
+    type            = "LINUX_CONTAINER"
+    privileged_mode = local.privileged_mode
+
+    dynamic "environment_variable" {
+      for_each = var.ecr_name == null ? [] : [1]
+      content {
+        name  = "IMAGE_REPO_NAME"
+        value = var.ecr_name
+      }
+    }
+
+    dynamic "environment_variable" {
+      for_each = var.use_docker_credentials ? [1] : []
+      content {
+        name  = "DOCKERHUB_USER"
+        value = "/dockerhub/user"
+        type  = "PARAMETER_STORE"
+      }
+    }
+
+    dynamic "environment_variable" {
+      for_each = var.use_docker_credentials ? [1] : []
+      content {
+        name  = "DOCKERHUB_PASS"
+        value = "/dockerhub/pass"
+        type  = "PARAMETER_STORE"
+      }
+    }
+
+    dynamic "environment_variable" {
+      for_each = var.use_repo_access_github_token ? [1] : []
+      content {
+        name  = "REPO_ACCESS_GITHUB_TOKEN_SECRETS_ID"
+        value = var.central_account_github_token_aws_secret_arn
+        type = "SECRETS_MANAGER"
+      }
+    }
+  }
+
+  source {
+    type      = "CODEPIPELINE"
+    buildspec = var.buildspec
+  }
+
+  tags = var.tags
+}

--- a/codepipeline.tf
+++ b/codepipeline.tf
@@ -1,0 +1,163 @@
+data "aws_iam_policy_document" "codepipeline_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["codepipeline.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "codepipeline" {
+  name               = "codepipeline-${local.codepipeline_name}"
+  assume_role_policy = data.aws_iam_policy_document.codepipeline_assume.json
+
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "codepipeline_baseline" {
+  statement {
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.artifact.arn}/*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "codebuild:BatchGetBuilds",
+      "codebuild:StartBuild"
+    ]
+    resources = [aws_codebuild_project.project.arn]
+  }
+
+}
+
+resource "aws_iam_role_policy" "codepipeline_baseline" {
+  name   = "codepipeline-baseline-${local.codepipeline_name}"
+  role   = aws_iam_role.codepipeline.id
+  policy = data.aws_iam_policy_document.codepipeline_baseline.json
+}
+
+resource "aws_codepipeline" "pipeline" {
+  name     = local.codepipeline_name
+  role_arn = aws_iam_role.codepipeline.arn
+
+  dynamic "artifact_store" {
+    for_each = var.create_cross_region_resources ? [1] : []
+    content {
+      location = aws_s3_bucket.artifact.id
+      type     = "S3"
+      region   = local.account_region
+
+      encryption_key {
+          id   = var.svcs_account_virginia_kms_cmk_arn_for_s3
+          type = "KMS"
+      }
+    }
+  }
+
+  dynamic "artifact_store" {
+    for_each = !var.create_cross_region_resources ? [1] : []
+    content {
+      location = aws_s3_bucket.artifact.id
+      type     = "S3"
+
+      encryption_key {
+          id   = var.svcs_account_virginia_kms_cmk_arn_for_s3
+          type = "KMS"
+      }
+    }
+  }
+
+  dynamic "artifact_store" {
+    for_each = var.create_ireland_region_resources ? [1] :[]
+    content {
+      location = aws_s3_bucket.artifact_ireland[0].id
+      type     = "S3"
+      region   = local.ireland_region
+
+      encryption_key {
+          id   = var.svcs_account_ireland_kms_cmk_arn_for_s3
+          type = "KMS"
+      }
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "ThirdParty"
+      provider         = "GitHub"
+      version          = "1"
+      output_artifacts = ["code"]
+
+      configuration = {
+        Owner                = var.github_repo_owner
+        Repo                 = var.github_repo_name
+        Branch               = var.github_branch_name
+        OAuthToken           = var.github_oauth_token
+        PollForSourceChanges = "false"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+      name             = "Build"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["code"]
+      version          = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.project.id
+      }
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_codepipeline_webhook" "github" {
+  # Only create the webhook if create_github_webhook is set to true
+  count           = var.create_github_webhook ? 1 : 0
+  name            = local.codepipeline_name
+  authentication  = "GITHUB_HMAC"
+  target_action   = "Source"
+  target_pipeline = aws_codepipeline.pipeline.name
+
+  authentication_configuration {
+    secret_token = var.github_oauth_token
+  }
+
+  filter {
+    json_path    = "$.ref"
+    match_equals = "refs/heads/{Branch}"
+  }
+}
+
+resource "github_repository_webhook" "aws_codepipeline" {
+  count      = var.create_github_webhook ? 1 : 0
+  repository = var.github_repo_name
+
+  configuration {
+    url          = aws_codepipeline_webhook.github[0].url
+    content_type = "json"
+    secret       = var.github_oauth_token
+  }
+
+  events = ["push"]
+}

--- a/codepipeline.tf
+++ b/codepipeline.tf
@@ -10,7 +10,7 @@ data "aws_iam_policy_document" "codepipeline_assume" {
 }
 
 resource "aws_iam_role" "codepipeline" {
-  name               = "codepipeline-${local.codepipeline_name}"
+  name               = "codepipeline-ci-${local.codepipeline_name}"
   assume_role_policy = data.aws_iam_policy_document.codepipeline_assume.json
 
   tags = var.tags
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "codepipeline_baseline" {
 }
 
 resource "aws_iam_role_policy" "codepipeline_baseline" {
-  name   = "codepipeline-baseline-${local.codepipeline_name}"
+  name   = "codepipeline-ci-baseline-${local.codepipeline_name}"
   role   = aws_iam_role.codepipeline.id
   policy = data.aws_iam_policy_document.codepipeline_baseline.json
 }

--- a/ecr.tf
+++ b/ecr.tf
@@ -1,0 +1,44 @@
+resource "aws_ecr_repository" "repository" {
+  count = var.deploy_type == "ecr" || var.deploy_type == "ecs" ? 1 : 0
+  name = var.ecr_name
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "ecr_cross_account_get_access_policy" {
+  count = var.deploy_type == "ecr" || var.deploy_type == "ecs" ? 1 : 0
+  statement {
+    sid = "Allow get access of the codebuild artifacts from deployment accounts"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetRepositoryPolicy",
+      "ecr:DescribeRepositories",
+      "ecr:ListImages",
+      "ecr:DescribeImages",
+      "ecr:GetAuthorizationToken",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+
+      values = [
+          var.aws_organization_id
+      ]
+    }
+  }
+}
+
+resource "aws_ecr_repository_policy" "ecr_cross_account_get_access" {
+  count = var.deploy_type == "ecr" || var.deploy_type == "ecs" ? 1 : 0
+  repository = aws_ecr_repository.repository[0].name
+  policy = data.aws_iam_policy_document.ecr_cross_account_get_access_policy[0].json
+}

--- a/locals.tf
+++ b/locals.tf
@@ -14,10 +14,12 @@ locals {
                           {
                             identifier_prefix = "function_zip"
                             object_name = "lambda.zip"
+                            object_path = var.function_name
                           } :
                           {
                             identifier_prefix = "imagedefinitions_file"
                             object_name = "imagedefinitions.zip"
+                            object_path = var.ecr_name
                           })
   codebuild_name = var.name
   codepipeline_name = var.name

--- a/locals.tf
+++ b/locals.tf
@@ -14,7 +14,7 @@ locals {
                           {
                             identifier_prefix = "function_zip"
                             object_name = "lambda.zip"
-                            object_path = var.function_name
+                            object_path = var.lambda_function_name
                           } :
                           {
                             identifier_prefix = "imagedefinitions_file"

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,24 @@
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+data "aws_region" "ireland" {
+    provider = aws.ireland
+}
+
+locals {
+  account_region  = data.aws_region.current.name
+  account_id      = data.aws_caller_identity.current.account_id
+  ireland_region  = data.aws_region.ireland.name
+
+  privileged_mode = var.deploy_type == "ecr" || var.deploy_type == "ecs" || var.privileged_mode ? true : false
+  artifact_attributes = (var.deploy_type == "lambda" ?
+                          {
+                            identifier_prefix = "function_zip"
+                            object_name = "lambda.zip"
+                          } :
+                          {
+                            identifier_prefix = "imagedefinitions_file"
+                            object_name = "imagedefinitions.zip"
+                          })
+  codebuild_name = var.name
+  codepipeline_name = var.name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,45 @@
+output "codebuild_project_id" {
+  value = aws_codebuild_project.project.id
+}
+
+output "codebuild_project_arn" {
+  value = aws_codebuild_project.project.arn
+}
+
+output "artifact_bucket_id" {
+  value = aws_s3_bucket.artifact.id
+}
+
+output "artifact_bucket_arn" {
+  value = aws_s3_bucket.artifact.arn
+}
+
+output "output_artifact_object_name" {
+  value = (var.deploy_type == "lambda" ?
+            "${var.function_name}/${local.artifact_attributes["object_name"]}" :
+            var.deploy_type == "ecs" ? "${var.ecr_name}/${local.artifact_attributes["object_name"]}" : null)
+}
+
+output "codebuild_iam_role_name" {
+  value = aws_iam_role.codebuild.id
+}
+
+output "codepipeline_id" {
+  value = aws_codepipeline.pipeline.id
+}
+
+output "codepipeline_arn" {
+  value = aws_codepipeline.pipeline.arn
+}
+
+output "ecr_repository_name" {
+  value =  var.deploy_type == "ecr" || var.deploy_type == "ecs" ? aws_ecr_repository.repository[0].name : null
+}
+
+output "ecr_repository_url" {
+  value = var.deploy_type == "ecr" || var.deploy_type == "ecs" ? aws_ecr_repository.repository[0].repository_url : null
+}
+
+output "ecr_repository_arn" {
+  value = var.deploy_type == "ecr" || var.deploy_type == "ecs" ? aws_ecr_repository.repository[0].arn : null
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,7 +16,7 @@ output "artifact_bucket_arn" {
 
 output "output_artifact_object_name" {
   value = (var.deploy_type == "lambda" ?
-            "${var.function_name}/${local.artifact_attributes["object_name"]}" :
+            "${var.lambda_function_name}/${local.artifact_attributes["object_name"]}" :
             var.deploy_type == "ecs" ? "${var.ecr_name}/${local.artifact_attributes["object_name"]}" : null)
 }
 

--- a/s3.tf
+++ b/s3.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket" "artifact" {
-  # S3 bucket cannot be longer than 63 characters
-  bucket = lower(substr("codepipeline-ci-${local.account_region}-${local.account_id}-${var.name}", 0, 63))
+  # S3 bucket cannot be longer than 63 characters and cannot end with dash
+  bucket = trimsuffix(lower(substr("codepipeline-ci-${local.account_region}-${local.account_id}-${var.name}", 0, 63)), "-")
   acl    = "private"
   force_destroy = var.s3_bucket_force_destroy
 
@@ -231,8 +231,8 @@ resource "aws_iam_role_policy" "kms_full_access_policy" {
 # Cross-Region Resources
 resource "aws_s3_bucket" "artifact_ireland" {
   count  = var.create_ireland_region_resources ? 1 : 0
-  # S3 bucket cannot be longer than 63 characters
-  bucket = lower(substr("codepipeline-ci-${local.ireland_region}-${local.account_id}-${var.name}", 0, 63))
+  # S3 bucket cannot be longer than 63 characters and cannot end with dash
+  bucket = trimsuffix(lower(substr("codepipeline-ci-${local.ireland_region}-${local.account_id}-${var.name}", 0, 63)), "-")
   acl    = "private"
   force_destroy = var.s3_bucket_force_destroy
   provider = aws.ireland

--- a/s3.tf
+++ b/s3.tf
@@ -1,0 +1,321 @@
+resource "aws_s3_bucket" "artifact" {
+  # S3 bucket cannot be longer than 63 characters
+  bucket = lower(substr("codepipeline-ci-${local.account_region}-${local.account_id}-${var.name}", 0, 63))
+  acl    = "private"
+  force_destroy = var.s3_bucket_force_destroy
+
+  dynamic "versioning" {
+    for_each = var.deploy_type == "lambda" || var.deploy_type == "ecs" ? [1] : []
+    content {
+      enabled = true
+    }
+  }
+
+  dynamic "replication_configuration" {
+    for_each = var.create_cross_region_resources ? [1] : []
+    content {
+      role = aws_iam_role.artifact_replication[0].arn
+
+      dynamic "rules" {
+        for_each = var.create_ireland_region_resources ? [1] : []
+        content {
+          id     = "ireland_region_bucket_replication"
+          status = "Enabled"
+
+          source_selection_criteria {
+            sse_kms_encrypted_objects  {
+              enabled = true
+            }
+          }
+
+          destination {
+            bucket        = aws_s3_bucket.artifact_ireland[0].arn
+            storage_class = "STANDARD"
+            replica_kms_key_id  = var.svcs_account_ireland_kms_cmk_arn_for_s3
+          }
+        }
+      }
+    }
+  }
+
+  lifecycle_rule {
+    enabled = true
+
+    abort_incomplete_multipart_upload_days = 30
+
+    expiration {
+      days = 90
+    }
+
+    dynamic "noncurrent_version_expiration" {
+      for_each = var.deploy_type == "lambda" || var.deploy_type == "ecs" ? [1] : []
+      content {
+        days = 30
+      }
+    }
+  }
+
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "artifact_bucket_policy" {
+  count = var.deploy_type == "lambda" || var.deploy_type == "ecs" ? 1 : 0
+  statement {
+    sid = "Allow get object access of the codebuild artifacts from deployment accounts"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:GetObjectAcl"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.artifact.arn}/*"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+
+      values = [
+          var.aws_organization_id
+      ]
+    }
+  }
+
+  statement {
+    sid = "Allow list object access of the codebuild artifacts from deployment accounts"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:ListBucket",
+      "s3:ListBucketVersions",
+      "s3:ListBucketMultipartUploads",
+      "s3:GetBucket*"
+    ]
+
+    resources = [
+      aws_s3_bucket.artifact.arn
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+
+      values = [
+          var.aws_organization_id
+      ]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "artifact_bucket" {
+  count = var.deploy_type == "lambda" || var.deploy_type == "ecs" ? 1 : 0
+  bucket = aws_s3_bucket.artifact.id
+  policy = data.aws_iam_policy_document.artifact_bucket_policy[0].json
+}
+
+# S3 cross-region replication
+data "aws_iam_policy_document" "s3_assume" {
+  count = var.create_cross_region_resources ? 1 : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "artifact_replication" {
+  count = var.create_cross_region_resources ? 1 : 0
+  name               = "artifact-replication-${var.name}"
+  assume_role_policy = data.aws_iam_policy_document.s3_assume[0].json
+
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "s3_replicate_access" {
+  count = var.create_cross_region_resources ? 1 : 0
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetReplicationConfiguration",
+      "s3:ListBucket"
+    ]
+
+    resources = [
+      aws_s3_bucket.artifact.arn
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObjectVersionForReplication",
+      "s3:GetObjectVersionAcl",
+      "s3:GetObjectVersionTagging"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.artifact.arn}/*"
+    ]
+  }
+
+  dynamic "statement" {
+    for_each = var.create_ireland_region_resources ? [1] : []
+    content {
+      effect = "Allow"
+
+      actions = [
+        "s3:ReplicateObject",
+        "s3:ReplicateDelete",
+        "s3:ReplicateTags"
+      ]
+
+      resources = [
+        "${aws_s3_bucket.artifact_ireland[0].arn}/*"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "s3_replicate_access_policy" {
+  count  = var.create_cross_region_resources ? 1 : 0
+  name   = "s3-replicate-access"
+  role   = aws_iam_role.artifact_replication[0].name
+  policy = data.aws_iam_policy_document.s3_replicate_access[0].json
+}
+
+data "aws_iam_policy_document" "kms_full_access" {
+  count = local.create_cross_region_resources ? 1 : 0
+  statement {
+    actions = [
+      "kms:Decrypt"
+    ]
+    resources = [
+      var.svcs_account_virginia_kms_cmk_arn_for_s3
+    ]
+  }
+
+  dynamic "statement" {
+    for_each = var.create_ireland_region_resources ? [1] :[]
+    content {
+      actions = [
+        "kms:Encrypt"
+      ]
+
+      resources = [
+        var.svcs_account_ireland_kms_cmk_arn_for_s3
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "kms_full_access_policy" {
+  count = var.create_cross_region_resources ? 1 : 0
+  name = "kms-full-access"
+  role   = aws_iam_role.artifact_replication[0].name
+  policy = data.aws_iam_policy_document.kms_full_access[0].json
+}
+
+# Cross-Region Resources
+resource "aws_s3_bucket" "artifact_ireland" {
+  count  = var.create_ireland_region_resources ? 1 : 0
+  # S3 bucket cannot be longer than 63 characters
+  bucket = lower(substr("codepipeline-ci-${local.ireland_region}-${local.account_id}-${var.name}", 0, 63))
+  acl    = "private"
+  force_destroy = var.s3_bucket_force_destroy
+  provider = aws.ireland
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    enabled = true
+
+    abort_incomplete_multipart_upload_days = 30
+
+    expiration {
+      days = 90
+    }
+
+    noncurrent_version_expiration {
+        days = 30
+    }
+  }
+
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "artifact_bucket_ireland_policy" {
+  count = var.create_ireland_region_resources ? 1 : 0
+  statement {
+    sid = "Allow get object access of the codebuild artifacts from deployment accounts"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:GetObjectAcl"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.artifact_ireland[0].arn}/*"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+
+      values = [
+          var.aws_organization_id
+      ]
+    }
+  }
+
+  statement {
+    sid = "Allow list object access of the codebuild artifacts from deployment accounts"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:ListBucket",
+      "s3:ListBucketVersions",
+      "s3:ListBucketMultipartUploads",
+      "s3:GetBucket*"
+    ]
+
+    resources = [
+      aws_s3_bucket.artifact_ireland[0].arn
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+
+      values = [
+          var.aws_organization_id
+      ]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "artifact_bucket_ireland" {
+  count = var.create_ireland_region_resources ? 1 : 0
+  provider = aws.ireland
+  bucket = aws_s3_bucket.artifact_ireland[0].id
+  policy = data.aws_iam_policy_document.artifact_bucket_ireland_policy[0].json
+}

--- a/s3.tf
+++ b/s3.tf
@@ -196,7 +196,7 @@ resource "aws_iam_role_policy" "s3_replicate_access_policy" {
 }
 
 data "aws_iam_policy_document" "kms_full_access" {
-  count = local.create_cross_region_resources ? 1 : 0
+  count = var.create_cross_region_resources ? 1 : 0
   statement {
     actions = [
       "kms:Decrypt"

--- a/s3.tf
+++ b/s3.tf
@@ -22,6 +22,7 @@ resource "aws_s3_bucket" "artifact" {
           id     = "ireland_region_bucket_replication"
           status = "Enabled"
 
+          prefix = local.artifact_attributes["object_path"]
           source_selection_criteria {
             sse_kms_encrypted_objects  {
               enabled = true

--- a/variables.tf
+++ b/variables.tf
@@ -184,3 +184,8 @@ variable "s3_bucket_force_destroy" {
                 Set to true if var.deploy_type is ecs or lambda.
                 EOT
 }
+
+varialbe "aws_organization_id" {
+  type         = string
+  description  = "(Required) The AWS organization ID."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "name" { #reserved
   type        = string
-  description = "(Required) The name associated with the pipeline and assoicated resources. i.e.: app-name"
+  description = "(Required) The name associated with the pipeline and assoicated resources. i.e.: app-name."
 }
 
 variable "deploy_type" { #reserved
@@ -22,22 +22,19 @@ variable "codebuild_image" { #reserved
 
 variable "build_compute_type" { #reserved
   type        = string
-  description = "(Optional) The codebuild environment compute type.
-                  Defaults to BUILD_GENERAL1_SMALL."
+  description = "(Optional) The codebuild environment compute type. Defaults to BUILD_GENERAL1_SMALL."
   default     = "BUILD_GENERAL1_SMALL"
 }
 
 variable "logs_retention_in_days" { #reserved
   type        = number
-  description = "(Optional) Days to keep the cloudwatch logs for the codebuild project.
-                  Defaults to 14."
+  description = "(Optional) Days to keep the cloudwatch logs for the codebuild project. Defaults to 14."
   default     = 14
 }
 
 variable "privileged_mode" { #reserved
   type        = bool
-  description = "(Optional) Use privileged mode for docker containers.
-                  Defaults to false."
+  description = "(Optional) Use privileged mode for docker containers. Defaults to false."
   default     = false
 }
 
@@ -70,8 +67,7 @@ variable "github_oauth_token" { #reserved
 
 variable "function_name" { #reserved
   type        = string
-  description = "(Optional) The name of the lambda function to update.
-                  Required if var.deploy_type is lambda."
+  description = "(Optional) The name of the lambda function to update. Required if var.deploy_type is lambda."
   default     = null
 }
 
@@ -95,17 +91,21 @@ variable "buildspec" { #reserved
 
 variable "central_account_github_token_aws_secret_arn" { #reserved
   type        = string
-  description = "(Optional) The AWS secret ARN for the repo access Github token.
-                  The secret is created in the shared service account.
-                  Required if var.use_repo_access_github_token is true."
+  description = <<EOT
+                (Optional) The AWS secret ARN for the repo access Github token.
+                The secret is created in the shared service account.
+                Required if var.use_repo_access_github_token is true.
+                EOT
   default     = null
 }
 
 variable "central_account_github_token_aws_kms_cmk_arn" { #reserved
   type        = string
-  description = "(Optional) The us-east-1 region AWS KMS customer managered key ARN for encrypting the repo access Github token AWS secret.
-                  The key is created in the shared service account.
-                  Required if var.use_repo_access_github_token is true."
+  description = <<EOT
+                (Optional) The us-east-1 region AWS KMS customer managered key ARN for encrypting the repo access Github token AWS secret.
+                The key is created in the shared service account.
+                Required if var.use_repo_access_github_token is true.
+                EOT
   default     = null
 }
 
@@ -115,56 +115,72 @@ variable "non_default_aws_provider_configurations" {
     profile_name = string,
     allowed_account_ids = list(string)
   }))
-  description = "(Required) A mapping of AWS provider configurations for cross-region resources creation.
-                  The configuration for Ireland region in the shared service account is required at the minimum." 
+  description = <<EOT
+                (Required) A mapping of AWS provider configurations for cross-region resources creation.
+                The configuration for Ireland region in the shared service account is required at the minimum.
+                EOT
   default = {}
 }
 
 variable "use_repo_access_github_token" {
   type        = bool
-  description = "(Optional) Allow the AWS codebuild IAM role read access to the REPO_ACCESS_GITHUB_TOKEN secrets manager secret in the shared service account.
-                  Defaults to false."
+  description = <<EOT
+                (Optional) Allow the AWS codebuild IAM role read access to the REPO_ACCESS_GITHUB_TOKEN secrets manager secret in the shared service account.
+                Defaults to false.
+                EOT
   default     = false
 }
 
 variable "create_cross_region_resources" {
   type        = bool
-  description = "(Required) Create the pipeline associated resources in all regions specified in var.non_default_aws_provider_configurations.
-                  Set to true if var.deploy_type is ecs or lambda."
+  description = <<EOT
+                (Required) Create the pipeline associated resources in all regions specified in var.non_default_aws_provider_configurations.
+                Set to true if var.deploy_type is ecs or lambda.
+                EOT
 }
 
 variable "create_ireland_region_resources" {
   type        = bool
-  description = "(Required) Create the pipeline associated resources in the Ireland region.
-                  Set to true if var.deploy_type is ecs or lambda."
+  description = <<EOT
+                (Required) Create the pipeline associated resources in the Ireland region.
+                Set to true if var.deploy_type is ecs or lambda.
+                EOT
 }
 
 variable "svcs_account_virginia_kms_cmk_arn_for_secrets_manager" {
   type        = string
-  description = "(Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting secrets manager data.
-                  The key is created in the shared service account.
-                  Required if var.use_repo_access_github_token is true."
+  description = <<EOT
+                (Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting secrets manager data.
+                The key is created in the shared service account.
+                Required if var.use_repo_access_github_token is true.
+                EOT
   default     = null
 }
 
 variable "svcs_account_virginia_kms_cmk_arn_for_s3" {
   type        = string
-  description = "(Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting s3 data.
+  description = <<EOT
+                (Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting s3 data.
                   The key is created in the shared service account.
-                  Required if var.deploy_type is ecs or lambda."
+                  Required if var.deploy_type is ecs or lambda.
+                EOT
   default     = null
 }
 
 variable "svcs_account_ireland_kms_cmk_arn_for_s3" {
   type        = string
-  description = "(Optional) The eu-west-1 region AWS KMS customer managed key ARN for encrypting s3 data.
-                  The key is created in the shared service account.
-                  Required if var.create_ireland_region_resources is true."
+  description = <<EOT
+                (Optional) The eu-west-1 region AWS KMS customer managed key ARN for encrypting s3 data.
+                The key is created in the shared service account.
+                Required if var.create_ireland_region_resources is true.
+                EOT
   default     = null
 }
 
 variable "s3_bucket_force_destroy" {
   type        = bool
-  description = "(Required) Delete all objects in S3 bucket upon bucket deletion. S3 objects are not recoverable.
-                  Set to true if var.deploy_type is ecs or lambda."
+  description = <<EOT
+                (Required) Delete all objects in S3 bucket upon bucket deletion. S3 objects are not recoverable.
+                Set to true if var.deploy_type is ecs or lambda.
+                EOT
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,10 +8,9 @@ variable "deploy_type" { #reserved
   description = "(Required) Must be one of the following ( ecr, ecs, lambda )."
 }
 
-variable "ecr_name" { #reserved
-  type        = string
-  description = "(Optional) The name of the ECR repo. Required if var.deploy_type is ecr or ecs."
-  default     = null
+variable "aws_organization_id" {
+  type         = string
+  description  = "(Required) The AWS organization ID."
 }
 
 variable "codebuild_image" { #reserved
@@ -26,16 +25,16 @@ variable "build_compute_type" { #reserved
   default     = "BUILD_GENERAL1_SMALL"
 }
 
+variable "buildspec" { #reserved
+  type        = string
+  description = "(Optional) The name of the buildspec file to use with codebuild. Defaults to buildspec.yml."
+  default     = "buildspec.yml"
+}
+
 variable "logs_retention_in_days" { #reserved
   type        = number
   description = "(Optional) Days to keep the cloudwatch logs for the codebuild project. Defaults to 14."
   default     = 14
-}
-
-variable "privileged_mode" { #reserved
-  type        = bool
-  description = "(Optional) Use privileged mode for docker containers. Defaults to false."
-  default     = false
 }
 
 variable "tags" { #reserved
@@ -65,48 +64,10 @@ variable "github_oauth_token" { #reserved
   description = "(Required) The GitHub oauth token."
 }
 
-variable "lambda_function_name" { #reserved
-  type        = string
-  description = "(Optional) The name of the lambda function to update. Required if var.deploy_type is lambda."
-  default     = null
-}
-
 variable "create_github_webhook" { #reserved
   type        = bool
   description = "(Optional) Create the github webhook that triggers codepipeline. Defaults to true."
   default     = true
-}
-
-variable "use_docker_credentials" { #reserved
-  type        = bool
-  description = "(Optional) Use dockerhub credentals stored in parameter store. Defaults to false."
-  default     = false
-}
-
-variable "buildspec" { #reserved
-  type        = string
-  description = "(Optional) The name of the buildspec file to use with codebuild. Defaults to buildspec.yml."
-  default     = "buildspec.yml"
-}
-
-variable "svcs_account_github_token_aws_secret_arn" { #reserved
-  type        = string
-  description = <<EOT
-                (Optional) The AWS secret ARN for the repo access Github token.
-                The secret is created in the shared service account.
-                Required if var.use_repo_access_github_token is true.
-                EOT
-  default     = null
-}
-
-variable "svcs_account_github_token_aws_kms_cmk_arn" { #reserved
-  type        = string
-  description = <<EOT
-                (Optional) The us-east-1 region AWS KMS customer managered key ARN for encrypting the repo access Github token AWS secret.
-                The key is created in the shared service account.
-                Required if var.use_repo_access_github_token is true.
-                EOT
-  default     = null
 }
 
 variable "non_default_aws_provider_configurations" {
@@ -122,13 +83,18 @@ variable "non_default_aws_provider_configurations" {
   default = {}
 }
 
-variable "use_repo_access_github_token" {
+variable "lambda_function_name" { #reserved
+  type        = string
+  description = "(Optional) The name of the lambda function to update. Required if var.deploy_type is lambda."
+  default     = null
+}
+
+variable "s3_bucket_force_destroy" {
   type        = bool
   description = <<EOT
-                (Optional) Allow the AWS codebuild IAM role read access to the REPO_ACCESS_GITHUB_TOKEN secrets manager secret in the shared service account.
-                Defaults to false.
+                (Required) Delete all objects in S3 bucket upon bucket deletion. S3 objects are not recoverable.
+                Set to true if var.deploy_type is ecs or lambda.
                 EOT
-  default     = false
 }
 
 variable "create_cross_region_resources" {
@@ -147,12 +113,12 @@ variable "create_ireland_region_resources" {
                 EOT
 }
 
-variable "svcs_account_virginia_kms_cmk_arn_for_secrets_manager" {
+variable "svcs_account_ireland_kms_cmk_arn_for_s3" {
   type        = string
   description = <<EOT
-                (Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting secrets manager data.
+                (Optional) The eu-west-1 region AWS KMS customer managed key ARN for encrypting s3 data.
                 The key is created in the shared service account.
-                Required if var.use_repo_access_github_token is true.
+                Required if var.create_ireland_region_resources is true.
                 EOT
   default     = null
 }
@@ -167,25 +133,49 @@ variable "svcs_account_virginia_kms_cmk_arn_for_s3" {
   default     = null
 }
 
-variable "svcs_account_ireland_kms_cmk_arn_for_s3" {
+variable "ecr_name" { #reserved
+  type        = string
+  description = "(Optional) The name of the ECR repo. Required if var.deploy_type is ecr or ecs."
+  default     = null
+}
+
+variable "privileged_mode" { #reserved
+  type        = bool
+  description = "(Optional) Use privileged mode for docker containers. Defaults to false."
+  default     = false
+}
+
+variable "use_docker_credentials" { #reserved
+  type        = bool
+  description = "(Optional) Use dockerhub credentals stored in parameter store. Defaults to false."
+  default     = false
+}
+
+variable "use_repo_access_github_token" {
+  type        = bool
+  description = <<EOT
+                (Optional) Allow the AWS codebuild IAM role read access to the REPO_ACCESS_GITHUB_TOKEN secrets manager secret in the shared service account.
+                Defaults to false.
+                EOT
+  default     = false
+}
+
+variable "svcs_account_github_token_aws_secret_arn" { #reserved
   type        = string
   description = <<EOT
-                (Optional) The eu-west-1 region AWS KMS customer managed key ARN for encrypting s3 data.
-                The key is created in the shared service account.
-                Required if var.create_ireland_region_resources is true.
+                (Optional) The AWS secret ARN for the repo access Github token.
+                The secret is created in the shared service account.
+                Required if var.use_repo_access_github_token is true.
                 EOT
   default     = null
 }
 
-variable "s3_bucket_force_destroy" {
-  type        = bool
+variable "svcs_account_github_token_aws_kms_cmk_arn" { #reserved
+  type        = string
   description = <<EOT
-                (Required) Delete all objects in S3 bucket upon bucket deletion. S3 objects are not recoverable.
-                Set to true if var.deploy_type is ecs or lambda.
+                (Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting the repo access Github token AWS secret.
+                The key is created in the shared service account.
+                Required if var.use_repo_access_github_token is true.
                 EOT
-}
-
-variable "aws_organization_id" {
-  type         = string
-  description  = "(Required) The AWS organization ID."
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,170 @@
+variable "name" { #reserved
+  type        = string
+  description = "(Required) The name associated with the pipeline and assoicated resources. i.e.: app-name"
+}
+
+variable "deploy_type" { #reserved
+  type        = string
+  description = "(Required) Must be one of the following ( ecr, ecs, lambda )."
+}
+
+variable "ecr_name" { #reserved
+  type        = string
+  description = "(Optional) The name of the ECR repo. Required if var.deploy_type is ecr or ecs."
+  default     = null
+}
+
+variable "codebuild_image" { #reserved
+  type        = string
+  description = "(Optional) The codebuild image to use. Defaults to aws/codebuild/amazonlinux2-x86_64-standard:1.0."
+  default     = "aws/codebuild/amazonlinux2-x86_64-standard:1.0"
+}
+
+variable "build_compute_type" { #reserved
+  type        = string
+  description = "(Optional) The codebuild environment compute type.
+                  Defaults to BUILD_GENERAL1_SMALL."
+  default     = "BUILD_GENERAL1_SMALL"
+}
+
+variable "logs_retention_in_days" { #reserved
+  type        = number
+  description = "(Optional) Days to keep the cloudwatch logs for the codebuild project.
+                  Defaults to 14."
+  default     = 14
+}
+
+variable "privileged_mode" { #reserved
+  type        = bool
+  description = "(Optional) Use privileged mode for docker containers.
+                  Defaults to false."
+  default     = false
+}
+
+variable "tags" { #reserved
+  type        = map
+  description = "(Optional) A mapping of tags to assign to the resource"
+  default     = {}
+}
+
+variable "github_repo_owner" { #reserved
+  type        = string
+  description = "(Required) The owner of the GitHub repo."
+}
+
+variable "github_repo_name" { #reserved
+  type        = string
+  description = "(Required) The name of the GitHub repository."
+}
+
+variable "github_branch_name" { #reserved
+  type        = string
+  description = "(Optional) The git branch name to use for the codebuild project. Defaults to master."
+  default     = "master"
+}
+
+variable "github_oauth_token" { #reserved
+  type        = string
+  description = "(Required) The GitHub oauth token."
+}
+
+variable "function_name" { #reserved
+  type        = string
+  description = "(Optional) The name of the lambda function to update.
+                  Required if var.deploy_type is lambda."
+  default     = null
+}
+
+variable "create_github_webhook" { #reserved
+  type        = bool
+  description = "(Optional) Create the github webhook that triggers codepipeline. Defaults to true."
+  default     = true
+}
+
+variable "use_docker_credentials" { #reserved
+  type        = bool
+  description = "(Optional) Use dockerhub credentals stored in parameter store. Defaults to false."
+  default     = false
+}
+
+variable "buildspec" { #reserved
+  type        = string
+  description = "(Optional) The name of the buildspec file to use with codebuild. Defaults to buildspec.yml."
+  default     = "buildspec.yml"
+}
+
+variable "central_account_github_token_aws_secret_arn" { #reserved
+  type        = string
+  description = "(Optional) The AWS secret ARN for the repo access Github token.
+                  The secret is created in the shared service account.
+                  Required if var.use_repo_access_github_token is true."
+  default     = null
+}
+
+variable "central_account_github_token_aws_kms_cmk_arn" { #reserved
+  type        = string
+  description = "(Optional) The us-east-1 region AWS KMS customer managered key ARN for encrypting the repo access Github token AWS secret.
+                  The key is created in the shared service account.
+                  Required if var.use_repo_access_github_token is true."
+  default     = null
+}
+
+variable "non_default_aws_provider_configurations" {
+  type = map(object({
+    region_name = string,
+    profile_name = string,
+    allowed_account_ids = list(string)
+  }))
+  description = "(Required) A mapping of AWS provider configurations for cross-region resources creation.
+                  The configuration for Ireland region in the shared service account is required at the minimum." 
+  default = {}
+}
+
+variable "use_repo_access_github_token" {
+  type        = bool
+  description = "(Optional) Allow the AWS codebuild IAM role read access to the REPO_ACCESS_GITHUB_TOKEN secrets manager secret in the shared service account.
+                  Defaults to false."
+  default     = false
+}
+
+variable "create_cross_region_resources" {
+  type        = bool
+  description = "(Required) Create the pipeline associated resources in all regions specified in var.non_default_aws_provider_configurations.
+                  Set to true if var.deploy_type is ecs or lambda."
+}
+
+variable "create_ireland_region_resources" {
+  type        = bool
+  description = "(Required) Create the pipeline associated resources in the Ireland region.
+                  Set to true if var.deploy_type is ecs or lambda."
+}
+
+variable "svcs_account_virginia_kms_cmk_arn_for_secrets_manager" {
+  type        = string
+  description = "(Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting secrets manager data.
+                  The key is created in the shared service account.
+                  Required if var.use_repo_access_github_token is true."
+  default     = null
+}
+
+variable "svcs_account_virginia_kms_cmk_arn_for_s3" {
+  type        = string
+  description = "(Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting s3 data.
+                  The key is created in the shared service account.
+                  Required if var.deploy_type is ecs or lambda."
+  default     = null
+}
+
+variable "svcs_account_ireland_kms_cmk_arn_for_s3" {
+  type        = string
+  description = "(Optional) The eu-west-1 region AWS KMS customer managed key ARN for encrypting s3 data.
+                  The key is created in the shared service account.
+                  Required if var.create_ireland_region_resources is true."
+  default     = null
+}
+
+variable "s3_bucket_force_destroy" {
+  type        = bool
+  description = "(Required) Delete all objects in S3 bucket upon bucket deletion. S3 objects are not recoverable.
+                  Set to true if var.deploy_type is ecs or lambda."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -65,7 +65,7 @@ variable "github_oauth_token" { #reserved
   description = "(Required) The GitHub oauth token."
 }
 
-variable "function_name" { #reserved
+variable "lambda_function_name" { #reserved
   type        = string
   description = "(Optional) The name of the lambda function to update. Required if var.deploy_type is lambda."
   default     = null
@@ -89,7 +89,7 @@ variable "buildspec" { #reserved
   default     = "buildspec.yml"
 }
 
-variable "central_account_github_token_aws_secret_arn" { #reserved
+variable "svcs_account_github_token_aws_secret_arn" { #reserved
   type        = string
   description = <<EOT
                 (Optional) The AWS secret ARN for the repo access Github token.
@@ -99,7 +99,7 @@ variable "central_account_github_token_aws_secret_arn" { #reserved
   default     = null
 }
 
-variable "central_account_github_token_aws_kms_cmk_arn" { #reserved
+variable "svcs_account_github_token_aws_kms_cmk_arn" { #reserved
   type        = string
   description = <<EOT
                 (Optional) The us-east-1 region AWS KMS customer managered key ARN for encrypting the repo access Github token AWS secret.
@@ -185,7 +185,7 @@ variable "s3_bucket_force_destroy" {
                 EOT
 }
 
-varialbe "aws_organization_id" {
+variable "aws_organization_id" {
   type         = string
   description  = "(Required) The AWS organization ID."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,9 @@
-variable "name" { #reserved
+variable "name" {
   type        = string
   description = "(Required) The name associated with the pipeline and assoicated resources. i.e.: app-name."
 }
 
-variable "deploy_type" { #reserved
+variable "deploy_type" {
   type        = string
   description = "(Required) Must be one of the following ( ecr, ecs, lambda )."
 }
@@ -13,58 +13,58 @@ variable "aws_organization_id" {
   description  = "(Required) The AWS organization ID."
 }
 
-variable "codebuild_image" { #reserved
+variable "codebuild_image" {
   type        = string
   description = "(Optional) The codebuild image to use. Defaults to aws/codebuild/amazonlinux2-x86_64-standard:1.0."
   default     = "aws/codebuild/amazonlinux2-x86_64-standard:1.0"
 }
 
-variable "build_compute_type" { #reserved
+variable "build_compute_type" {
   type        = string
   description = "(Optional) The codebuild environment compute type. Defaults to BUILD_GENERAL1_SMALL."
   default     = "BUILD_GENERAL1_SMALL"
 }
 
-variable "buildspec" { #reserved
+variable "buildspec" {
   type        = string
   description = "(Optional) The name of the buildspec file to use with codebuild. Defaults to buildspec.yml."
   default     = "buildspec.yml"
 }
 
-variable "logs_retention_in_days" { #reserved
+variable "logs_retention_in_days" {
   type        = number
   description = "(Optional) Days to keep the cloudwatch logs for the codebuild project. Defaults to 14."
   default     = 14
 }
 
-variable "tags" { #reserved
+variable "tags" {
   type        = map
   description = "(Optional) A mapping of tags to assign to the resource"
   default     = {}
 }
 
-variable "github_repo_owner" { #reserved
+variable "github_repo_owner" {
   type        = string
   description = "(Required) The owner of the GitHub repo."
 }
 
-variable "github_repo_name" { #reserved
+variable "github_repo_name" {
   type        = string
   description = "(Required) The name of the GitHub repository."
 }
 
-variable "github_branch_name" { #reserved
+variable "github_branch_name" {
   type        = string
   description = "(Optional) The git branch name to use for the codebuild project. Defaults to master."
   default     = "master"
 }
 
-variable "github_oauth_token" { #reserved
+variable "github_oauth_token" {
   type        = string
   description = "(Required) The GitHub oauth token."
 }
 
-variable "create_github_webhook" { #reserved
+variable "create_github_webhook" {
   type        = bool
   description = "(Optional) Create the github webhook that triggers codepipeline. Defaults to true."
   default     = true
@@ -83,18 +83,13 @@ variable "non_default_aws_provider_configurations" {
   default = {}
 }
 
-variable "lambda_function_name" { #reserved
-  type        = string
-  description = "(Optional) The name of the lambda function to update. Required if var.deploy_type is lambda."
-  default     = null
-}
-
 variable "s3_bucket_force_destroy" {
   type        = bool
   description = <<EOT
-                (Required) Delete all objects in S3 bucket upon bucket deletion. S3 objects are not recoverable.
-                Set to true if var.deploy_type is ecs or lambda.
+                (Optional) Delete all objects in S3 bucket upon bucket deletion. S3 objects are not recoverable.
+                Set to true if var.deploy_type is ecs or lambda. Defaults to false.
                 EOT
+  default     = false
 }
 
 variable "create_cross_region_resources" {
@@ -131,19 +126,25 @@ variable "svcs_account_virginia_kms_cmk_arn_for_s3" {
                 EOT
 }
 
-variable "ecr_name" { #reserved
+variable "lambda_function_name" {
+  type        = string
+  description = "(Optional) The name of the lambda function to update. Required if var.deploy_type is lambda."
+  default     = null
+}
+
+variable "ecr_name" {
   type        = string
   description = "(Optional) The name of the ECR repo. Required if var.deploy_type is ecr or ecs."
   default     = null
 }
 
-variable "privileged_mode" { #reserved
+variable "privileged_mode" {
   type        = bool
   description = "(Optional) Use privileged mode for docker containers. Defaults to false."
   default     = false
 }
 
-variable "use_docker_credentials" { #reserved
+variable "use_docker_credentials" {
   type        = bool
   description = "(Optional) Use dockerhub credentals stored in parameter store. Defaults to false."
   default     = false
@@ -158,7 +159,7 @@ variable "use_repo_access_github_token" {
   default     = false
 }
 
-variable "svcs_account_github_token_aws_secret_arn" { #reserved
+variable "svcs_account_github_token_aws_secret_arn" {
   type        = string
   description = <<EOT
                 (Optional) The AWS secret ARN for the repo access Github token.
@@ -168,7 +169,7 @@ variable "svcs_account_github_token_aws_secret_arn" { #reserved
   default     = null
 }
 
-variable "svcs_account_github_token_aws_kms_cmk_arn" { #reserved
+variable "svcs_account_github_token_aws_kms_cmk_arn" {
   type        = string
   description = <<EOT
                 (Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting the repo access Github token AWS secret.

--- a/variables.tf
+++ b/variables.tf
@@ -126,11 +126,9 @@ variable "svcs_account_ireland_kms_cmk_arn_for_s3" {
 variable "svcs_account_virginia_kms_cmk_arn_for_s3" {
   type        = string
   description = <<EOT
-                (Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting s3 data.
+                (Required) The us-east-1 region AWS KMS customer managed key ARN for encrypting s3 data.
                   The key is created in the shared service account.
-                  Required if var.deploy_type is ecs or lambda.
                 EOT
-  default     = null
 }
 
 variable "ecr_name" { #reserved

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
#### PR description

What is it for?
The change is to add the TF module templates for the CI(build) AWS code pipeline in the shared service account.
All artifacts generated from code build will be stored in the shared service account and accessed by resources in the client specific accounts. The CD(deployment) code pipeline will be created in each client specific account.

#### Testing instructions

- Sample usage of the module can be found at:
   - For lambda: https://github.com/globeandmail/terraform-plans/blob/DSOPS-3/accounts/ds-ml-shared-svcs-prod/lambda_codepipeline.tf#L169
   - For ECS: https://github.com/globeandmail/terraform-plans/blob/DSOPS-3-ecs/accounts/ds-ml-shared-svcs-prod/ecs_codepipeline.tf#L155
   - For ECR: https://github.com/globeandmail/terraform-plans/blob/DSOPS-3-ecr/accounts/ds-ml-shared-svcs-prod/ecr_codepipeline.tf#L155

#### JIRA ticket information

Story: [DSOPS-3](https://jira.theglobeandmail.com/browse/DSOPS-3)
