### PR TITLE
AHP-917 Add optional variable s3_block_public_access

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -59,6 +59,16 @@ resource "aws_s3_bucket" "artifact" {
   tags = var.tags
 }
 
+resource "aws_s3_bucket_public_access_block" "artifact" {
+  count  = var.s3_block_public_access ? 1 : 0
+  bucket = aws_s3_bucket.artifact.id
+
+  block_public_acls   = true
+  block_public_policy = true
+  ignore_public_acls  = true
+  restrict_public_buckets  = true
+}
+
 data "aws_iam_policy_document" "artifact_bucket_policy" {
   count = var.deploy_type == "lambda" || var.deploy_type == "ecs" ? 1 : 0
   statement {
@@ -256,6 +266,16 @@ resource "aws_s3_bucket" "artifact_ireland" {
   }
 
   tags = var.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "artifact_ireland" {
+  count  = var.create_ireland_region_resources && var.s3_block_public_access ? 1 : 0
+  bucket = aws_s3_bucket.artifact_ireland.id
+
+  block_public_acls   = true
+  block_public_policy = true
+  ignore_public_acls  = true
+  restrict_public_buckets  = true
 }
 
 data "aws_iam_policy_document" "artifact_bucket_ireland_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -178,3 +178,9 @@ variable "svcs_account_github_token_aws_kms_cmk_arn" {
                 EOT
   default     = null
 }
+
+variable "s3_block_public_access" {
+  type = bool
+  description = "(Optional) Enable the S3 block public access setting for the artifact bucket."
+  default = false
+}


### PR DESCRIPTION
#### PR description

What is it for?
The PR is to address the failed security checks in AWS security hub.
 - add aws_s3_bucket_public_access_block resource when var.s3_block_public_access = true (optional variable with default = false).
 
#### Testing instructions

- Verify in AWS security hub that the failed security check is fixed: S3.8 S3 Block Public Access setting should be enabled at the bucket-level.

#### JIRA ticket information

Story: [AHP-917](https://jira.theglobeandmail.com/browse/AHP-917)
